### PR TITLE
Non-specific version

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ For the purposes of this document, we're installing PHP CodeSniffer on a project
 From the integrated terminal within Visual Studio Code, enter the following command:
 
 ```
-$ composer require "squizlabs/php_codesniffer=2.*"
+$ composer require "squizlabs/php_codesniffer=*"
 ```
 
 This will create `composer.json`, tell it where to locate the PHP CodeSniffer, and install it in a `vendor` directory. Once this is done, we need the WordPress Coding Standard ruleset.


### PR DESCRIPTION
Ask composer to require the latest version of php_codesniffer (as opposed to 2.x which is outdated now)